### PR TITLE
Add reference data

### DIFF
--- a/data-truth/README.md
+++ b/data-truth/README.md
@@ -1,0 +1,19 @@
+# Reference data
+
+For the Scenario Hub we use incident data over a Sunday-Saturday [(MMWR) week](https://github.com/covid19-forecast-hub-europe/covid19-forecast-hub-europe/wiki/Targets-and-horizons#horizon-and-frequency) for [32 countries](././data-locations/locations_eu.csv). Note that data sources vary, including in week definitions, with ECDC and Our World in Data typically using a Monday-Sunday (ISO) week.
+
+
+Data | Source | Download | Includes 32 Hub countries | Notes
+--- | --- | --- | --- | ---
+Cases | [Euro Forecast Hub / JHU](https://github.com/covid19-forecast-hub-europe/covid19-forecast-hub-europe/tree/main/data-truth) | [csv](https://raw.githubusercontent.com/covid19-forecast-hub-europe/covid19-forecast-hub-europe/main/data-truth/JHU/truth_JHU-Incident%20Cases.csv) | Yes
+Cases by age | [ECDC](https://www.ecdc.europa.eu/en/publications-data/covid-19-data-14-day-age-notification-rate-new-cases) | [csv](https://opendata.ecdc.europa.eu/covid19/agecasesnational/csv/data.csv)| No | Missing** GR, GB, CH
+Deaths | [Euro Forecast Hub / JHU](https://github.com/covid19-forecast-hub-europe/covid19-forecast-hub-europe/tree/main/data-truth) | [csv](https://raw.githubusercontent.com/covid19-forecast-hub-europe/covid19-forecast-hub-europe/main/data-truth/JHU/truth_JHU-Incident%20Deaths.csv) | Yes |
+Hospitalisations | [Euro Forecast Hub / ECDC](https://github.com/covid19-forecast-hub-europe/covid19-forecast-hub-europe/tree/main/data-truth) | [csv](https://raw.githubusercontent.com/covid19-forecast-hub-europe/covid19-forecast-hub-europe/main/data-truth/ECDC/truth_ECDC-Incident%20Hospitalizations.csv) | No | Data available based on quality: see [notes](https://github.com/covid19-forecast-hub-europe/covid19-forecast-hub-europe/tree/main/code/auto_download/hospitalisations#readme)
+Vaccinations | [Our World in Data](https://github.com/owid/covid-19-data/tree/master/public/data#readme) | [csv](https://github.com/owid/covid-19-data/blob/master/public/data/vaccinations/vaccinations.csv?raw=true) | Yes | [Example R code](./code/vaccinations.R)
+Vaccinations by age group | [Our World in Data](https://github.com/owid/covid-19-data/tree/master/public/data#readme) | [csv](https://raw.githubusercontent.com/owid/covid-19-data/master/public/data/vaccinations/vaccinations-by-age-group.csv) | Yes | [Example R code](./code/vaccinations.R)
+Testing | [Our World in Data](https://github.com/owid/covid-19-data/tree/master/public/data#readme) | [csv](https://github.com/owid/covid-19-data/blob/master/public/data/testing/covid-testing-all-observations.csv?raw=true) | Yes | [Example R code](./code/testing.R)
+Variants | [ECDC](https://www.ecdc.europa.eu/en/publications-data/data-virus-variants-covid-19-eueea) | [csv](https://opendata.ecdc.europa.eu/covid19/virusvariant/csv/data.csv) | No | Missing** GR, GB, CH. More countries available at: [GISAID](https://www.gisaid.org/) |
+Response measures | [ECDC](https://www.ecdc.europa.eu/en/publications-data/download-data-response-measures-covid-19) | [csv](https://www.ecdc.europa.eu/sites/default/files/documents/response_graphs_data_2022-02-24.csv) | No | Missing** GR, GB, CH. More countries available at alternative source: [OxCGRT](https://www.bsg.ox.ac.uk/research/research-projects/covid-19-government-response-tracker)
+Contact matrices | [CoMix](http://www.socialcontactdata.org/data/) |  | No | Includes 14 hub countries
+
+** Missing: Greece (GR), United Kingdom (GB), Switzerland (CH)

--- a/data-truth/code/testing.R
+++ b/data-truth/code/testing.R
@@ -1,0 +1,18 @@
+# Testing
+library(dplyr)
+library(readr)
+library(here)
+
+# Get 32 Euro hub locations
+hub <- read_csv("https://raw.githubusercontent.com/covid19-forecast-hub-europe/covid19-scenario-hub-europe/main/data-locations/locations_eu.csv") %>%
+  select("location_name", "location", "population")
+
+# Source: Our World In Data
+# Metadata: https://github.com/owid/covid-19-data/tree/master/public/data
+
+# Get testing data
+owid_test <- read_csv("https://github.com/owid/covid-19-data/blob/master/public/data/testing/covid-testing-all-observations.csv?raw=true") %>%
+  mutate(location = countrycode::countrycode(`ISO code`, "iso3c", "iso2c")) %>%
+  filter(location %in% hub$location) %>%
+  select("location", "Date", "Entity",
+         "Daily change in cumulative total":"Short-term tests per case")

--- a/data-truth/code/vaccination.R
+++ b/data-truth/code/vaccination.R
@@ -1,0 +1,27 @@
+# European vaccination data
+library(dplyr)
+library(readr)
+library(here)
+
+# Get 32 Euro hub locations
+hub <- read_csv("https://raw.githubusercontent.com/covid19-forecast-hub-europe/covid19-scenario-hub-europe/main/data-locations/locations_eu.csv") %>%
+  select("location_name", "location", "population")
+
+# Source: Our World In Data
+# Metadata: https://github.com/owid/covid-19-data/tree/master/public/data
+
+# Get total population vaccination data
+owid_vax <- read_csv("https://github.com/owid/covid-19-data/blob/master/public/data/vaccinations/vaccinations.csv?raw=true") %>%
+  filter(location %in% hub$location_name) %>%
+  rename("location_name" = "location") %>%
+  select(-"iso_code") %>%
+  left_join(hub, by = "location_name") %>%
+  select("location", "location_name", "population", "date", everything())
+
+# Get vaccination data by age
+# - Note: age data not available for Denmark (DE), Greece (GR), Netherlands (NL), United Kingdom (GB)
+owid_vax_age <- read_csv("https://raw.githubusercontent.com/owid/covid-19-data/master/public/data/vaccinations/vaccinations-by-age-group.csv") %>%
+  filter(location %in% hub$location_name) %>%
+  rename("location_name" = "location") %>%
+  left_join(hub, by = "location_name") %>%
+  select("location", "location_name", "population", "date", everything())


### PR DESCRIPTION
Adds some links to suggested data sources.

- Includes: cases / by age, deaths, vaccinations / by age, testing, NPIs, contacts. 

- Links to metadata and download, and notes where data are incomplete for all the hub countries.

- Also adds some code to download/filter vaccination and testing data since this is likely to be a common task.