### PR TITLE
Put all metadata related to model details together

### DIFF
--- a/data-processed/ECDC-CM_ONE/metadata-ECDC-CM_ONE.txt
+++ b/data-processed/ECDC-CM_ONE/metadata-ECDC-CM_ONE.txt
@@ -6,21 +6,22 @@ website_url: https://www.ecdc.europa.eu/en
 license: cc-by-nc-4.0
 team_model_designation: primary
 methods: 'Discrete-time, deterministic, mean-field SEIR-type compartmental model on metapopulation level. Population divided by age, vaccination status, and previous recovery; incl. seasonality, BA2 & behavior.'
-modeling_NPI: 'Considered that behaviour converges to a "new normal", which may be close, but not equal to, pre-pandemic behaviour'
-compliance_NPI: Not applicable
-contact_tracing: Not applicable
-testing: Not applicable
-vaccine_efficacy_transmission: See vaccine_immunity_duration
-vaccine_efficacy_delay: Not applicable
-vaccine_hesitancy: Not applicable
-vaccine_immunity_duration: 'We assume exponential waning of neutralisation levels that is related to vaccine efficacy (VE) against infection via the following paper: https://doi.org/10.1038/s41591-021-01377-8. The starting VEs against infections for each vaccine product and age group is obtained from literature. The exponential decay time of neutralisation levels is then defined in such a way to obtain 40% (or 60%) decrease VE against infection after 10 (or 4) months. We assume no plateau.'
-natural_immunity_duration: We assume exponential waning of natural immunity; the exponential time is obtained from definition that natural immunity protection lowers by 40% (or 60%) within 10 (or 4) months. We assume no plateau.
-case_fatality_rate: Depending on age and vaccination status, ranging from 2.71e-9 to 1.3e-2
-infection_fatality_rate: Depending on age and vaccination status, ranging from 8.14e-9 to 3.9e-2
-asymptomatics: Not applicable
-age_groups: '[0-4, 5-9, 10-14, 15-17, 18-24, 25-49, 50-59, 60-69, 70-79, 80+]'
-importations: Not considered relevant for this submission round, but model does provide the functionality to specify importation of cases
-confidence_interval_method: Quantiles followed from MCMC and prior distribution of parameters
-calibration: Markov chain Monte Carlo 
-spatial_structure: Not applicable
+model_details:
+  modeling_NPI: 'Considered that behaviour converges to a "new normal", which may be close, but not equal to, pre-pandemic behaviour'
+  compliance_NPI: Not applicable
+  contact_tracing: Not applicable
+  testing: Not applicable
+  vaccine_efficacy_transmission: See vaccine_immunity_duration
+  vaccine_efficacy_delay: Not applicable
+  vaccine_hesitancy: Not applicable
+  vaccine_immunity_duration: 'We assume exponential waning of neutralisation levels that is related to vaccine efficacy (VE) against infection via the following paper: https://doi.org/10.1038/s41591-021-01377-8. The starting VEs against infections for each vaccine product and age group is obtained from literature. The exponential decay time of neutralisation levels is then defined in such a way to obtain 40% (or 60%) decrease VE against infection after 10 (or 4) months. We assume no plateau.'
+  natural_immunity_duration: We assume exponential waning of natural immunity; the exponential time is obtained from definition that natural immunity protection lowers by 40% (or 60%) within 10 (or 4) months. We assume no plateau.
+  case_fatality_rate: Depending on age and vaccination status, ranging from 2.71e-9 to 1.3e-2
+  infection_fatality_rate: Depending on age and vaccination status, ranging from 8.14e-9 to 3.9e-2
+  asymptomatics: Not applicable
+  age_groups: '[0-4, 5-9, 10-14, 15-17, 18-24, 25-49, 50-59, 60-69, 70-79, 80+]'
+  importations: Not considered relevant for this submission round, but model does provide the functionality to specify importation of cases
+  confidence_interval_method: Quantiles followed from MCMC and prior distribution of parameters
+  calibration: Markov chain Monte Carlo
+  spatial_structure: Not applicable
 methods_long: 'We use a discrete-time, deterministic, mean-field compartmental model to describe the spread of COVID-19 on a metapopulation level in a given country. The population is divided into ten age groups, four vaccination groups (0, 1, 2, or 3 vaccine doses), and two recovery groups (recovered from a pre-Omicron variant of concern or not). Hence, there are 80 population groups in total. To estimate the contact network between age groups, we make use of POLYMOD contact data. For every group, the disease progression follows an SEIR-type model, with additional compartments that correspond to individuals in a pre-symptomatic, mild infectious, severe infectious, hospitalised, or deceased state. We obtain the average of the infection rate between population groups by fitting the model to past data with a MCMC method. For the remaining parameters, we specified the prior distribution based on values from literature and expert opinions. The model includes seasonality, BA2 and behaviour.'

--- a/data-processed/ICM-agentModel/metadata-ICM-agentModel.txt
+++ b/data-processed/ICM-agentModel/metadata-ICM-agentModel.txt
@@ -11,22 +11,23 @@ team_funding: The model and this document were created as part of the "ICM Epide
 data_inputs: "Polish Ministry of Health (general epidemic data: number of cases, deaths, etc.) and Polish National Institute for Public Health (Detailed epidemic data: time of hospitalization, age, symptoms, contact tracing etc.)"
 citation: 'Niedzielewski, Karol and Nowosielski, Jędrzej and Bartczuk, Rafał and Dreger, Filip and Górski, Łukasz and Gruziel-Słomka, Magdalena and Kaczorek, Artur and Kisielewski, Jan and Krupa, Bartosz and Moszyński, Antoni and Radwan, Maciej and Semeniuk, Marcin and Zieliński, Jakub and Rakowski, Franciszek, The Overview, Design Concepts and Details Protocol of ICM Epidemiological Model (Pdyn 1.5) (February 21, 2022). Available at SSRN: https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4039054'
 methods_long: "The main idea behind our agent-based model is a representation of the social structure of population of Poland to the level of individual citizen and its social contacts. Our model has resolution in space and contexts. It means it can follow development of epidemic on geographical grid in 1x1km resolution as well as through physical contact in various characteristic contexts of social life."
-modeling_NPI: NPIs are represented in the model by variation (in time and space) of agent contacting rates in appropriate contexts such as schools, workplaces etc.
-compliance_NPI: NPIs are represented in the model by variation (in time and space) of agent contacting rates in appropriate contexts such as schools, workplaces etc.
-contact_tracing: Not applicable
-testing: simple scaling of the real infections to theconfirmed cases
-vaccine_efficacy_transmission: VE is expressed as the reduction of daily probability of infection. In simple terms, the reduction constitutes partial immunity which is expressed as the product of some maximum immunity level and the profile of immunity variation in time.
-vaccine_efficacy_delay: 14 days since first dose or booster dose
-vaccine_hesitancy: vaccinations in model consistent with official data for powiats (counties) and age groups 
-vaccine_immunity_duration: The immunity builds up to the maximum level for first 14 days, next it stays at maximum until 3 months after vaccination, finally the immunity decays gradually to predefined level.
-natural_immunity_duration: Maximum immunity within 3 months since recovery (total immunity in case of the same variant as in previous infection), after 3 months immunity decays gradually to predefined level.
-case_fatality_rate: Not applicable
-infection_fatality_rate: derived from probabilities of transitions between agent states 
-asymptomatics: dependent on the agent age
-age_groups: one-year groups
-importations: seed agents introduced for each virus variant
-confidence_interval_method: Not applicable
-calibration: The hybrid approach is utilised. Many model parameters are based on literature (e.g. duration of latent state) The absolute infectivity of the wild type (parameter alpha ) and  the reference (assuming usual behaviour) fraction of symptomatic agents contributing to their non-household contexts (parameter f) is optimised using Bayesian search and historic confirmed cases data. Finally, some parameters, most notably multipliers of context contacting rates, are calibrated using the trial and error method.   
-spatial_structure: model agents are geo-referenced
+model_details:
+  modeling_NPI: NPIs are represented in the model by variation (in time and space) of agent contacting rates in appropriate contexts such as schools, workplaces etc.
+  compliance_NPI: NPIs are represented in the model by variation (in time and space) of agent contacting rates in appropriate contexts such as schools, workplaces etc.
+  contact_tracing: Not applicable
+  testing: simple scaling of the real infections to theconfirmed cases
+  vaccine_efficacy_transmission: VE is expressed as the reduction of daily probability of infection. In simple terms, the reduction constitutes partial immunity which is expressed as the product of some maximum immunity level and the profile of immunity variation in time.
+  vaccine_efficacy_delay: 14 days since first dose or booster dose
+  vaccine_hesitancy: vaccinations in model consistent with official data for powiats (counties) and age groups
+  vaccine_immunity_duration: The immunity builds up to the maximum level for first 14 days, next it stays at maximum until 3 months after vaccination, finally the immunity decays gradually to predefined level.
+  natural_immunity_duration: Maximum immunity within 3 months since recovery (total immunity in case of the same variant as in previous infection), after 3 months immunity decays gradually to predefined level.
+  case_fatality_rate: Not applicable
+  infection_fatality_rate: derived from probabilities of transitions between agent states
+  asymptomatics: dependent on the agent age
+  age_groups: one-year groups
+  importations: seed agents introduced for each virus variant
+  confidence_interval_method: Not applicable
+  calibration: The hybrid approach is utilised. Many model parameters are based on literature (e.g. duration of latent state) The absolute infectivity of the wild type (parameter alpha ) and  the reference (assuming usual behaviour) fraction of symptomatic agents contributing to their non-household contexts (parameter f) is optimised using Bayesian search and historic confirmed cases data. Finally, some parameters, most notably multipliers of context contacting rates, are calibrated using the trial and error method.
+  spatial_structure: model agents are geo-referenced
 
 

--- a/data-processed/JBUD-HMXK/metadata-JBUD-HMXK.txt
+++ b/data-processed/JBUD-HMXK/metadata-JBUD-HMXK.txt
@@ -8,20 +8,21 @@ team_model_designation: primary
 methods: 'Heavily modified infection-age SIR-X model with waning immunity, vaccinations, seasonality and undetected cases. '
 data_inputs: See GitHub for full description
 methods_long: See GitHub for full description
-modeling_NPI: Not applicable
-compliance_NPI: Not applicable
-contact_tracing: Not applicable
-testing: Not applicable
-vaccine_efficacy_transmission: 'Initial vaccine effectiveness (full dose): 90 %; Initial vaccine effectiveness (booster): 50 %' 
-vaccine_efficacy_delay: 7 days
-vaccine_hesitancy: Not applicable
-vaccine_immunity_duration: '105/70 days '
-natural_immunity_duration: '202/135 days ' 
-case_fatality_rate: Not applicable
-infection_fatality_rate: Not applicable
-asymptomatics: 'Probability of diagnosis given symptoms: 75.00 %; Symptomatic proportion: 54.60 % '
-age_groups: Not applicable
-importations: Not applicable
-confidence_interval_method: Nonparametric
-calibration: Not applicable
-spatial_structure: Not applicable
+model_details:
+  modeling_NPI: Not applicable
+  compliance_NPI: Not applicable
+  contact_tracing: Not applicable
+  testing: Not applicable
+  vaccine_efficacy_transmission: 'Initial vaccine effectiveness (full dose): 90 %; Initial vaccine effectiveness (booster): 50 %'
+  vaccine_efficacy_delay: 7 days
+  vaccine_hesitancy: Not applicable
+  vaccine_immunity_duration: '105/70 days '
+  natural_immunity_duration: '202/135 days '
+  case_fatality_rate: Not applicable
+  infection_fatality_rate: Not applicable
+  asymptomatics: 'Probability of diagnosis given symptoms: 75.00 %; Symptomatic proportion: 54.60 % '
+  age_groups: Not applicable
+  importations: Not applicable
+  confidence_interval_method: Nonparametric
+  calibration: Not applicable
+  spatial_structure: Not applicable

--- a/data-processed/UC3M-EpiGraph/metadata-UC3M-EpiGraph.txt
+++ b/data-processed/UC3M-EpiGraph/metadata-UC3M-EpiGraph.txt
@@ -8,20 +8,21 @@ team_model_designation: primary
 methods: Agent-based parallel simulator that models individual interactions extracted from social networks and demographical data.
 team_funding: U3CM, Instituto de Salud Carlos III, Gobierno de España, European Commission
 citation: https://doi.org/10.3389/fpubh.2021.636023
-modeling_NPI: In this simulation we consider use of facemasks. With no changing conditions in their use for the period between March 13th 2022 and March 7th  2022 
-compliance_NPI: We assume that the NPI do not change during the period from March 2022 to March 2023
-contact_tracing: We consider that a certain percentage of the infected individuals are self-quarantined at home.
-testing: Not considered for this version of the code (we will include it in future versions)
-vaccine_efficacy_transmission: The vaccine efficacy depends on the number of doses, the virus variant and its related immunity is also subjected to waning. 
-vaccine_efficacy_delay: For Pfizer we consider, for the second doses and boosters, that after vaccination the maximum immunity is reached after 7 days. Then, it remains steady for 30 days and following this, it decreases following a gamma distribution. 
-vaccine_hesitancy: First and second doses = Children 47%, Adults 16%, Elderly people 4%; Booster = Children 100%, Adults 60%, Elderly people 10%
-vaccine_immunity_duration: 30 days after the dose, then waning following a gamma distribution
-natural_immunity_duration: 30 days after infection or (if the individual was already infected) after the vaccination, then waning following a gamma distribution
-case_fatality_rate: Age-dependant values and dependent on whether the individual has acquired immunity. Not subjected to waning. 
-infection_fatality_rate: Age-dependant values and dependent on whether the individual has acquired immunity. Not subjected to waning. 
-asymptomatics: We assume that 25% of the infected are asymptomatic
-age_groups: 0-5, 6-10, 10-15, 15-20, 20-30, 30-40, 40-50, 50-60, 60-70, 80-90, 90-100+
-importations: We use data provided the by Spanish National Health service. We scale the detected cases in order to estimate the real ones. 
-confidence_interval_method: Based on calibration and statistical analysis of multiple executions. 
-calibration: We calibrate the model using the time interval from July 2021 and March 2022
-spatial_structure: 10 cities, 5,018,260 inhabitants.
+model_details:
+  modeling_NPI: In this simulation we consider use of facemasks. With no changing conditions in their use for the period between March 13th 2022 and March 7th  2022
+  compliance_NPI: We assume that the NPI do not change during the period from March 2022 to March 2023
+  contact_tracing: We consider that a certain percentage of the infected individuals are self-quarantined at home.
+  testing: Not considered for this version of the code (we will include it in future versions)
+  vaccine_efficacy_transmission: The vaccine efficacy depends on the number of doses, the virus variant and its related immunity is also subjected to waning.
+  vaccine_efficacy_delay: For Pfizer we consider, for the second doses and boosters, that after vaccination the maximum immunity is reached after 7 days. Then, it remains steady for 30 days and following this, it decreases following a gamma distribution.
+  vaccine_hesitancy: First and second doses = Children 47%, Adults 16%, Elderly people 4%; Booster = Children 100%, Adults 60%, Elderly people 10%
+  vaccine_immunity_duration: 30 days after the dose, then waning following a gamma distribution
+  natural_immunity_duration: 30 days after infection or (if the individual was already infected) after the vaccination, then waning following a gamma distribution
+  case_fatality_rate: Age-dependant values and dependent on whether the individual has acquired immunity. Not subjected to waning.
+  infection_fatality_rate: Age-dependant values and dependent on whether the individual has acquired immunity. Not subjected to waning.
+  asymptomatics: We assume that 25% of the infected are asymptomatic
+  age_groups: 0-5, 6-10, 10-15, 15-20, 20-30, 30-40, 40-50, 50-60, 60-70, 80-90, 90-100+
+  importations: We use data provided the by Spanish National Health service. We scale the detected cases in order to estimate the real ones.
+  confidence_interval_method: Based on calibration and statistical analysis of multiple executions.
+  calibration: We calibrate the model using the time interval from July 2021 and March 2022
+  spatial_structure: 10 cities, 5,018,260 inhabitants.

--- a/data-processed/USC-SIkJalpha/metadata-USC-SIkJalpha.txt
+++ b/data-processed/USC-SIkJalpha/metadata-USC-SIkJalpha.txt
@@ -7,23 +7,24 @@ website_url: https://scc-usc.github.io/ReCOVER-COVID-19
 license: mit
 team_model_designation: primary
 methods: Uses SIKJalpha which models temporally varying infection, death, and hospitalization rates. Learning is performed by reducing the problem to multiple simple linear regression problems.
-modeling_NPI: No NPI included, contact changes over time derived from Cuebiq data.
-compliance_NPI: Not modeled.
-contact_tracing: Not applicable.
-testing: Not applicable.
-vaccine_efficacy_transmission: Not explicitly modeled
-vaccine_efficacy_delay: 14 days
-vaccine_hesitancy: A "suceptible-infected"model. Boosters are modeled such that the "susceptible" population is the eligible population who are yet to get a booster. To achieve the desired saturation level to create sub-scenarios, we increase the adoption rate over time.
-vaccine_immunity_duration: 'Only waning immunity is considered! The probability of transferring to partially immune state by at time t is modeled as a gamma distribution such that: (i) the median is as per the scenario; (ii) the efficacy (given the partial immune protection against infection) after the first 60 days is the "initial" vaccine efficacy.'
-natural_immunity_duration: Same as above
-case_fatality_rate: Learned from recent data.
-infection_fatality_rate: Learned from recent data.
-asymptomatics: Similar to the range obtained for the US states using the CDC sero-prevelance data from the CDC. Note that this covers the currect cumulative fraction of unreported, untested, and asymptomatic.
-age_groups: No stratification by age
-importations: Not applicable
-confidence_interval_method: We generate multiple trajectories by (i) Uniform sampling of the recently seen infection rates, under-reporting/asymptomatic population, vaccine coverage, waning parameters uncertainty, and variant prevelance. (ii) For each of the above case trajectories, we use multiple possibilities of death and hospitalization rates that have been seen in the recent past. The above results in multiple points for each day. Quantiles are generated based on sampling among these points for each day.
-calibration: 'All calibrations using regression. No manual-tuning other than the listed assumption and trivial settings: non-zero lag between infection and death.'
-spatial_structure: Not applicable.
+model_details:
+  modeling_NPI: No NPI included, contact changes over time derived from Cuebiq data.
+  compliance_NPI: Not modeled.
+  contact_tracing: Not applicable.
+  testing: Not applicable.
+  vaccine_efficacy_transmission: Not explicitly modeled
+  vaccine_efficacy_delay: 14 days
+  vaccine_hesitancy: A "suceptible-infected"model. Boosters are modeled such that the "susceptible" population is the eligible population who are yet to get a booster. To achieve the desired saturation level to create sub-scenarios, we increase the adoption rate over time.
+  vaccine_immunity_duration: 'Only waning immunity is considered! The probability of transferring to partially immune state by at time t is modeled as a gamma distribution such that: (i) the median is as per the scenario; (ii) the efficacy (given the partial immune protection against infection) after the first 60 days is the "initial" vaccine efficacy.'
+  natural_immunity_duration: Same as above
+  case_fatality_rate: Learned from recent data.
+  infection_fatality_rate: Learned from recent data.
+  asymptomatics: Similar to the range obtained for the US states using the CDC sero-prevelance data from the CDC. Note that this covers the currect cumulative fraction of unreported, untested, and asymptomatic.
+  age_groups: No stratification by age
+  importations: Not applicable
+  confidence_interval_method: We generate multiple trajectories by (i) Uniform sampling of the recently seen infection rates, under-reporting/asymptomatic population, vaccine coverage, waning parameters uncertainty, and variant prevelance. (ii) For each of the above case trajectories, we use multiple possibilities of death and hospitalization rates that have been seen in the recent past. The above results in multiple points for each day. Quantiles are generated based on sampling among these points for each day.
+  calibration: 'All calibrations using regression. No manual-tuning other than the listed assumption and trivial settings: non-zero lag between infection and death.'
+  spatial_structure: Not applicable.
 team_funding: National Science Foundation Award # 2135784
 data_inputs: Cases and deaths - JHU
 citation: |
@@ -38,14 +39,14 @@ methods_long: |
   Our model is able to quickly adapt to changing trends, and the variations in parameters
   during different times/policies allow us to forecast different scenarios such as
   what would happen if we were to disregard social distancing suggestions.
-  For each state, we model hospitalizations as a separate compartment, as a linear 
-  function of recent cases with heterogeneous rates. This means that for some 
-  hyper-parameter J, those who were infected at time t-1 to t-J will have a separate 
-  rate from those infected at t-(J+1) to t-2J, and so on. This is similar to how we 
-  perform death forecasts. For long-term forecasts (more than a few days in the future), 
-  the cases are forecasted first based on our SIkJalpha model, which forms the input to 
+  For each state, we model hospitalizations as a separate compartment, as a linear
+  function of recent cases with heterogeneous rates. This means that for some
+  hyper-parameter J, those who were infected at time t-1 to t-J will have a separate
+  rate from those infected at t-(J+1) to t-2J, and so on. This is similar to how we
+  perform death forecasts. For long-term forecasts (more than a few days in the future),
+  the cases are forecasted first based on our SIkJalpha model, which forms the input to
   hospitalization prediction. Age-specific compartments are tracked for individuals with waned immunity.
-  While we account for changing trends by putting more emphasis on recently seen data, 
+  While we account for changing trends by putting more emphasis on recently seen data,
   we assume that the trends will remain the same in the future for our point forecasts.
   Quantiles are generated by considering variations in the infection/fatality/hopsitalization
   over recent window. Variants are modeled separately as competing contagions

--- a/data-processed/UVA-EpiHiper/metadata-UVA-EpiHiper.txt
+++ b/data-processed/UVA-EpiHiper/metadata-UVA-EpiHiper.txt
@@ -6,23 +6,23 @@ model_contributors: Jiangzhuo Chen (UVA) <chenj@virginia.edu>, Stefan Hoops (UVA
 website_url: http://not.available.yet
 license: cc-by-4.0
 team_model_designation: primary
-
 methods: Our agent-based model EpiHiper simulates disease transmissions in a synthetic network. It models immune waning, immune escape, and NPIs; and is initialized with age stratified ground truth data.
-modeling_NPI: (i) A fraction of the population chooses to reduce non-essential (shopping, religion, and other) activities. (ii) All K-12 schools are closed from mid-June 2022 to mid-August 2022 and again from mid-December 2022 to the beginning of 2023. (iii) A fraction of symptomatic people choose to self-isolate themselves at home.
-compliance_NPI: Compliances are 15% on average for (i), 100% for (ii), and 75% for (iii).
-contact_tracing: Not applicable.
-testing: Not applicable.
-vaccine_efficacy_transmission: Not applicable.
-vaccine_efficacy_delay: as specified in the scenario description.
-vaccine_hesitancy: as specified in the scenario description.
-vaccine_immunity_duration: vaccinated people go to a partially immune state after a period that is sampled from an exponential distribution with either 10-month or 4-month median.
-natural_immunity_duration: recovered (from infections) people go to a partially immune state after a period that is sampled from an exponential distribution with either 10-month or 4-month median.
-case_fatality_rate: age stratified, specified based on recent COVID-19 literatures.
-infection_fatality_rate: age stratified, specified based on recent COVID-19 literatures.
-asymptomatics: 60% for naively susceptible people (without immunity), increased for people with immunity (from natural infection and/or vaccination).
-age_groups: preschool (0-4 years), students (5-17), adults (18-49), older adults (50-64) and seniors (65+).
-importations: Not applicable.
-confidence_interval_method: estimated from multiple replicates of simulations.
-calibration: For each state, we calibrate the transmissibility parameter in our disease model targeting daily confirmed cases in the recent weeks until the last date of fitting data.
-spatial_structure: embedded in our synthetic contact network model.
+model_details:
+  modeling_NPI: (i) A fraction of the population chooses to reduce non-essential (shopping, religion, and other) activities. (ii) All K-12 schools are closed from mid-June 2022 to mid-August 2022 and again from mid-December 2022 to the beginning of 2023. (iii) A fraction of symptomatic people choose to self-isolate themselves at home.
+  compliance_NPI: Compliances are 15% on average for (i), 100% for (ii), and 75% for (iii).
+  contact_tracing: Not applicable.
+  testing: Not applicable.
+  vaccine_efficacy_transmission: Not applicable.
+  vaccine_efficacy_delay: as specified in the scenario description.
+  vaccine_hesitancy: as specified in the scenario description.
+  vaccine_immunity_duration: vaccinated people go to a partially immune state after a period that is sampled from an exponential distribution with either 10-month or 4-month median.
+  natural_immunity_duration: recovered (from infections) people go to a partially immune state after a period that is sampled from an exponential distribution with either 10-month or 4-month median.
+  case_fatality_rate: age stratified, specified based on recent COVID-19 literatures.
+  infection_fatality_rate: age stratified, specified based on recent COVID-19 literatures.
+  asymptomatics: 60% for naively susceptible people (without immunity), increased for people with immunity (from natural infection and/or vaccination).
+  age_groups: preschool (0-4 years), students (5-17), adults (18-49), older adults (50-64) and seniors (65+).
+  importations: Not applicable.
+  confidence_interval_method: estimated from multiple replicates of simulations.
+  calibration: For each state, we calibrate the transmissibility parameter in our disease model targeting daily confirmed cases in the recent weeks until the last date of fitting data.
+  spatial_structure: embedded in our synthetic contact network model.
 methods_long: We use our agent-based model, called EpiHiper, which computes stochastic transmissions of a disease in a synthetic contact network between individuals and stochastic state transitions within each individual following a disease model. Our disease model is stratified by age group. The disease model is extended to have waning immunity. The immune waning has an exponential distribution with median of 10 months or 4 months, depending on the scenario, for the time to transition to a partially susceptible state; the protection on nodes in the partially susceptible state is as specified in the scenario description. Our simulations are initialized with prior infections (part of which have waned immunity), recent daily confirmed case counts, and prior vaccinations (part of which have waned immunity). Prior infections are derived from cumulative confirmed cases. We run EpiHiper simulations to produce daily infections, hospitalizations, and deaths; and each simulation runs for multiple replicates. We aggregate daily data to get weekly data and compute quantiles for each target from the multiple replicates.

--- a/data-processed/schema-metadata.yml
+++ b/data-processed/schema-metadata.yml
@@ -60,40 +60,62 @@ properties:
     type: string
   methods_long:
     type: string
-  modeling_NPI:
-    type: string
-  compliance_NPI:
-    type: string
-  contact_tracing:
-    type: string
-  testing:
-    type: string
-  vaccine_efficacy_transmission:
-    type: string
-  vaccine_efficacy_delay:
-    type: string
-  vaccine_hesitancy:
-    type: string
-  vaccine_immunity_duration:
-    type: string
-  natural_immunity_duration:
-    type: string
-  case_fatality_rate:
-    type: string
-  infection_fatality_rate:
-    type: string
-  asymptomatics:
-    type: string
-  age_groups:
-    type: string
-  importations:
-    type: string
-  confidence_interval_method:
-    type: string
-  calibration:
-    type: string
-  spatial_structure:
-    type: string
+  model_details:
+    type: object
+    properties:
+      modeling_NPI:
+        type: string
+      compliance_NPI:
+        type: string
+      contact_tracing:
+        type: string
+      testing:
+        type: string
+      vaccine_efficacy_transmission:
+        type: string
+      vaccine_efficacy_delay:
+        type: string
+      vaccine_hesitancy:
+        type: string
+      vaccine_immunity_duration:
+        type: string
+      natural_immunity_duration:
+        type: string
+      case_fatality_rate:
+        type: string
+      infection_fatality_rate:
+        type: string
+      asymptomatics:
+        type: string
+      age_groups:
+        type: string
+      importations:
+        type: string
+      confidence_interval_method:
+        type: string
+      calibration:
+        type: string
+      spatial_structure:
+        type: string
+    required:
+      - modeling_NPI
+      - compliance_NPI
+      - contact_tracing
+      - testing
+      - vaccine_efficacy_transmission
+      - vaccine_efficacy_delay
+      - vaccine_hesitancy
+      - vaccine_immunity_duration
+      - natural_immunity_duration
+      - case_fatality_rate
+      - infection_fatality_rate
+      - asymptomatics
+      - age_groups
+      - importations
+      - confidence_interval_method
+      - calibration
+      - spatial_structure
+    additionalProperties: false
 additionalProperties: false
 required:
   - team_name
@@ -104,20 +126,3 @@ required:
   - license
   - team_model_designation
   - methods
-  - modeling_NPI
-  - compliance_NPI
-  - contact_tracing
-  - testing
-  - vaccine_efficacy_transmission
-  - vaccine_efficacy_delay
-  - vaccine_hesitancy
-  - vaccine_immunity_duration
-  - natural_immunity_duration
-  - case_fatality_rate
-  - infection_fatality_rate
-  - asymptomatics
-  - age_groups
-  - importations
-  - confidence_interval_method
-  - calibration
-  - spatial_structure


### PR DESCRIPTION
I suggest we change slightly our metadata format to put all model details fields (the new fields we didn't have in the forecast hub) nested inside a new `model_details` field.

This makes it much easier to isolate these fields to generate a report about model features/details.

What do you think of this change @sbfnk, @kathsherratt?