### PR TITLE
update HubValidations

### DIFF
--- a/renv.lock
+++ b/renv.lock
@@ -62,7 +62,7 @@
       "RemoteUsername": "covid19-forecast-hub-europe",
       "RemoteRepo": "HubValidations",
       "RemoteRef": "origin-date",
-      "RemoteSha": "1787e834821926f209b91f7c025436a91a642de2",
+      "RemoteSha": "43d09951c9da933099f7c65f1fd1fd9784f3172f",
       "Remotes": "r-lib/rlang",
       "Requirements": [
         "dplyr",
@@ -76,7 +76,7 @@
         "rlang",
         "yaml"
       ],
-      "Hash": "0a6e0847b48555707ceed72eec4b53f9"
+      "Hash": "c6900d82f067f7eda370ec249ec3be0f"
     },
     "MASS": {
       "Package": "MASS",

--- a/renv.lock
+++ b/renv.lock
@@ -1775,14 +1775,14 @@
     },
     "scoringutils": {
       "Package": "scoringutils",
-      "Version": "1.1.4",
+      "Version": "1.1.5",
       "Source": "GitHub",
       "RemoteType": "github",
+      "RemoteHost": "api.github.com",
       "RemoteUsername": "epiforecasts",
       "RemoteRepo": "scoringutils",
-      "RemoteRef": "master",
-      "RemoteSha": "255721ae31b309d26e85d90e67c446447c190d39",
-      "RemoteHost": "api.github.com",
+      "RemoteRef": "main",
+      "RemoteSha": "3bf41d82364d2d9097357a88cf6537c551f195b7",
       "Requirements": [
         "R",
         "data.table",
@@ -1794,7 +1794,7 @@
         "scoringRules",
         "stats"
       ],
-      "Hash": "df722dee60a8c592c83b44f7ede5ea90"
+      "Hash": "5336a7b72d28c6024b6e9f998b24d527"
     },
     "selectr": {
       "Package": "selectr",


### PR DESCRIPTION
This updates HubValidations where an option to insert the country in the file name had been inserted in the wrong place, leading to validations failing.

This should now work as the pattern match includes the option to have two capital letters for the country code in the file name https://github.com/covid19-forecast-hub-europe/HubValidations/blob/43d09951c9da933099f7c65f1fd1fd9784f3172f/R/validate_model_data.R#L34

The PR also updates `scoringutils` where the name of the `master` branch has been changed to `main`.